### PR TITLE
Fix computePagesPerDay when pages is zero

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -6,8 +6,8 @@ export function computeDays(paginas, porDia){
 }
 export function computePagesPerDay(paginas, dias){
   const p = Math.max(0, Number(paginas)||0);
-  const d = Math.max(1, Number(dias)||1);
-  return Math.max(1, Math.ceil(p/d));
+  const d = Math.max(1, Number(dias)||0);
+  return p === 0 ? 0 : Math.max(1, Math.ceil(p/d));
 }
 export const store = {
   get(key, fallback){
@@ -42,3 +42,4 @@ export const firestore = {
     await deleteDoc(doc(db, 'users', uid, collectionName, id));
   }
 };
+

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -1,4 +1,3 @@
-
 import { computeDays, computePagesPerDay } from '../js/utils.js';
 const out = document.getElementById('out');
 function log(msg){ out.textContent += msg + '\n'; }
@@ -8,5 +7,7 @@ try{
   assertEq(computeDays(0,10), 1, 'computeDays min 1 day');
   assertEq(computePagesPerDay(100,10), 10, 'ppd 100/10');
   assertEq(computePagesPerDay(100,0), 100, 'days=0 treated as 1');
+  assertEq(computePagesPerDay(0,10), 0, 'ppd 0/10');
   log('All tests passed ✔️');
 }catch(e){ log('Test failed ❌: ' + e.message); }
+


### PR DESCRIPTION
## Summary
- handle zero pages in `computePagesPerDay`
- cover zero-page scenario in tests

## Testing
- `node --input-type=module <<'NODE'
import { computeDays, computePagesPerDay } from './public/js/utils.js';
function assertEq(a,b,msg){ if(a!==b) throw new Error(msg+` (got ${a}, expected ${b})`); }
assertEq(computeDays(100,20), 5, 'computeDays 100/20');
assertEq(computeDays(0,10), 1, 'computeDays min 1 day');
assertEq(computePagesPerDay(100,10), 10, 'ppd 100/10');
assertEq(computePagesPerDay(100,0), 100, 'days=0 treated as 1');
assertEq(computePagesPerDay(0,10), 0, 'ppd 0/10');
console.log('All tests passed ✔️');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a8b503e340832e8abf08906d7bf9ee