### PR TITLE
Fix Firestore imports and async data retrieval

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,4 +1,5 @@
 // Utils & storage
+import { collection, query, getDocs, setDoc, doc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 export function computeDays(paginas, porDia){
   const p = Math.max(0, Number(paginas)||0);
   const d = Math.max(1, Number(porDia)||0);
@@ -26,19 +27,23 @@ export function formatDate(d){ try{ return new Date(d).toISOString().slice(0,10)
 // Firebase Functions
 export const firestore = {
   async getAll(db, uid, collectionName){
+    if(!uid) return [];
     const q = query(collection(db, 'users', uid, collectionName));
     const snapshot = await getDocs(q);
     return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
   },
   async set(db, uid, collectionName, id, data){
+    if(!uid) return;
     await setDoc(doc(db, 'users', uid, collectionName, id), data);
   },
   async add(db, uid, collectionName, data){
+    if(!uid) return null;
     const newDoc = doc(collection(db, 'users', uid, collectionName));
     await setDoc(newDoc, data);
     return newDoc.id;
   },
   async del(db, uid, collectionName, id){
+    if(!uid) return;
     await deleteDoc(doc(db, 'users', uid, collectionName, id));
   }
 };

--- a/public/pages/configuracoes.js
+++ b/public/pages/configuracoes.js
@@ -1,10 +1,10 @@
 
-export function initPage(app){
+export async function initPage(app){
   document.getElementById('btn-gerar').addEventListener('click', ()=> app.toast('Código do acervo: acv_'+Math.random().toString(36).slice(2,7)));
   document.getElementById('btn-vincular').addEventListener('click', ()=> app.toast('Vinculado (demo)'));
   document.getElementById('btn-import').addEventListener('click', ()=> app.toast('Importar (demo)'));
-  document.getElementById('btn-export').addEventListener('click', ()=> {
-    const data = { books: app.getBooks(), readings: app.getReadings(), metas: app.getMetas() };
+  document.getElementById('btn-export').addEventListener('click', async ()=> {
+    const data = { books: await app.getBooks(), readings: await app.getReadings(), metas: await app.getMetas() };
     const blob = new Blob([JSON.stringify(data,null,2)], {type:'application/json'});
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a'); a.href = url; a.download = 'biblioflow-export.json'; a.click();

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -1,8 +1,8 @@
 
-export function initPage(app){
-  const books = app.getBooks();
-  const readings = app.getReadings();
-  const metas = app.getMetas();
+export async function initPage(app){
+  const books = await app.getBooks();
+  const readings = await app.getReadings();
+  const metas = await app.getMetas();
   const autores = new Set(books.map(b=>b.autor)).size;
   const streak = app.getStreak().current;
   document.getElementById('stat-livros').textContent = books.length;

--- a/public/pages/metas.js
+++ b/public/pages/metas.js
@@ -1,11 +1,11 @@
 
 import { uid } from '../js/utils.js';
-export function initPage(app){
+export async function initPage(app){
   const lista = document.getElementById('lista');
   const btnAdd = document.getElementById('btn-add');
 
-  function render(){
-    const metas = app.getMetas();
+  async function render(){
+    const metas = await app.getMetas();
     lista.innerHTML = metas.map(m=> card(m)).join('') || '<div class="badge">Nenhuma meta.</div>';
     lista.querySelectorAll('[data-edit]').forEach(btn => btn.addEventListener('click', ()=> openForm(btn.dataset.id)));
   }
@@ -24,8 +24,8 @@ export function initPage(app){
     </div>`;
   }
 
-  function openForm(id){
-    const all = app.getMetas();
+  async function openForm(id){
+    const all = await app.getMetas();
     const draft = app.pullMetaDraft();
     let meta = all.find(x=>x.id===id) || { id: uid('m'), tipo:'numero', titulo:'', desc:'', qtd:10, periodo:'2025', livro:'', prazo:'' , checklist:['']};
     if(draft){
@@ -82,8 +82,8 @@ export function initPage(app){
     }));
     el.querySelector('#btn-cancel').addEventListener('click', modal.close);
     const del = el.querySelector('#btn-del');
-    if(del) del.addEventListener('click', ()=>{
-      if(confirm('Excluir meta?')){ app.setMetas(all.filter(x=>x.id!==meta.id)); modal.close(); render(); app.toast('Meta excluída'); }
+    if(del) del.addEventListener('click', async ()=>{
+      if(confirm('Excluir meta?')){ await app.setMetas(all.filter(x=>x.id!==meta.id)); modal.close(); await render(); app.toast('Meta excluída'); }
     });
     const boxCL = el.querySelector('#checklist-box');
     const addCL = el.querySelector('#btn-add-check');
@@ -96,7 +96,7 @@ export function initPage(app){
         const row = e.target.closest('.row'); row.remove();
       }
     });
-    el.querySelector('#frm').addEventListener('submit', (ev)=>{
+    el.querySelector('#frm').addEventListener('submit', async (ev)=>{
       ev.preventDefault();
       const updated = { ...meta };
       updated.titulo = el.querySelector('#f-titulo').value.trim();
@@ -112,13 +112,13 @@ export function initPage(app){
       }else{
         updated.checklist = Array.from(boxCL.querySelectorAll('input')).map(i=> i.value.trim()).filter(Boolean);
       }
-      const arr = app.getMetas();
+      const arr = await app.getMetas();
       const idx = arr.findIndex(x=>x.id===updated.id);
       if(idx>=0) arr[idx]=updated; else arr.unshift(updated);
-      app.setMetas(arr); modal.close(); render(); app.toast('Salvo');
+      await app.setMetas(arr); modal.close(); await render(); app.toast('Salvo');
     });
   }
 
   btnAdd.addEventListener('click', ()=> openForm());
-  render();
+  await render();
 }


### PR DESCRIPTION
## Summary
- import missing Firestore helpers and guard against unauthenticated access
- await async data when rendering dashboard, metas and config pages

## Testing
- `node - <<'NODE'
import fs from 'fs';
import vm from 'vm';
let code = fs.readFileSync('./public/js/utils.js','utf-8');
code = code.replace(/import[^\n]+firebase-firestore[^\n]+\n/,'').replace(/export\s+/g,'');
const sandbox = { console, localStorage: { getItem(){ return null; }, setItem(){} }, structuredClone: global.structuredClone, Math, Number, Date };
vm.createContext(sandbox);
vm.runInContext(code, sandbox);
const { computeDays, computePagesPerDay } = sandbox;
const assert = (a,b,msg)=>{ if(a!==b) throw new Error(msg+` (got ${a}, expected ${b})`); };
assert(computeDays(100,20),5,'computeDays 100/20');
assert(computeDays(0,10),1,'computeDays min 1 day');
assert(computePagesPerDay(100,10),10,'ppd 100/10');
assert(computePagesPerDay(100,0),100,'days=0 treated as 1');
assert(computePagesPerDay(0,10),0,'ppd 0/10');
console.log('All tests passed ✔️');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a8be7e2ee4832eab0d8a1ef5a982d2