### PR TITLE
fix: guard dashboard stats against missing elements

### DIFF
--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -5,22 +5,31 @@ export async function initPage(app){
   const metas = await app.getMetas();
   const autores = new Set(books.map(b=>b.autor)).size;
   const streak = app.getStreak().current;
-  document.getElementById('stat-livros').textContent = books.length;
-  document.getElementById('stat-leituras').textContent = readings.length;
-  document.getElementById('stat-autores').textContent = autores;
-  document.getElementById('stat-metas').textContent = metas.length;
-  document.getElementById('stat-streak').textContent = '🔥 '+streak;
+
+  const setText = (id, text) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = text;
+  };
+
+  setText('stat-livros', books.length);
+  setText('stat-leituras', readings.length);
+  setText('stat-autores', autores);
+  setText('stat-metas', metas.length);
+  setText('stat-streak', '🔥 '+streak);
 
   // Extras
   const tempoH = (readings.length * 1.2).toFixed(1); // estimativa
-  document.getElementById('stat-tempo').textContent = tempoH+'h';
+  setText('stat-tempo', tempoH+'h');
   const temas = books.flatMap(b=> b.temas || []);
   const top = temas.sort().reduce((acc,t)=> (acc[t]=(acc[t]||0)+1, acc), {});
   const gen = Object.entries(top).sort((a,b)=> b[1]-a[1])[0]?.[0] || '-';
-  document.getElementById('stat-genero').textContent = gen;
+  setText('stat-genero', gen);
 
-  document.getElementById('go-feed').addEventListener('click', ()=> app.navTo('comunidade'));
+  const goFeed = document.getElementById('go-feed');
+  if (goFeed) goFeed.addEventListener('click', ()=> app.navTo('comunidade'));
   const feed = document.getElementById('feed');
-  const items = readings.slice(-5).map(r=> `<li>${r.titulo} — fim ${r.fim}</li>`).join('');
-  feed.innerHTML = items || '<li>Sem atividades recentes.</li>';
+  if (feed){
+    const items = readings.slice(-5).map(r=> `<li>${r.titulo} — fim ${r.fim}</li>`).join('');
+    feed.innerHTML = items || '<li>Sem atividades recentes.</li>';
+  }
 }


### PR DESCRIPTION
## Summary
- avoid `null` errors in dashboard stats by checking element existence before writing
- safely attach event listeners and update feed only when elements exist

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c0a79214832e989d041bbeb73b7e