### PR TITLE
Fix duplicate Firestore import and uid definition

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,8 +1,8 @@
-HEAD
 import {
   getFirestore,
   collection,
   doc,
+  getDoc,
   getDocs,
   addDoc,
   updateDoc,
@@ -22,7 +22,6 @@ import {
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 // Utils & storage
-import { collection, query, getDocs, setDoc, doc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 export function computeDays(paginas, porDia){
   const p = Math.max(0, Number(paginas)||0);
   const d = Math.max(1, Number(porDia)||0);
@@ -127,17 +126,6 @@ const auth = {
   updateProfile: async (app, newProfile) => {
     await updateProfile(app.auth.currentUser, newProfile);
   }
-};
-
-const uid = () => {
-  let a = new Uint32Array(3);
-  window.crypto.getRandomValues(a);
-  return (
-    performance.now().toString(36) +
-    Array.from(a)
-    .map((d) => d.toString(36))
-    .join("")
-  ).replace(/\./g, "");
 };
 
 export {


### PR DESCRIPTION
## Summary
- consolidate Firestore imports to prevent duplicate `collection` declaration
- remove redundant `uid` implementation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check public/js/utils.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad92dc97c0832ebef906cc65c04d94