### PR TITLE
fix duplicate uid export and cleanup utils

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,5 +1,4 @@
 import {
-  getFirestore,
   collection,
   doc,
   getDoc,
@@ -7,18 +6,15 @@ import {
   addDoc,
   updateDoc,
   deleteDoc,
-  query,
-  where,
-  limit
+  query
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import {
-  getAuth,
   onAuthStateChanged,
   signInWithPopup,
   GoogleAuthProvider,
   signOut,
   deleteUser,
-  updateProfile
+  updateProfile as fbUpdateProfile
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
 // Utils & storage
@@ -124,12 +120,11 @@ const auth = {
   },
   // Nova função para atualizar o perfil do usuário
   updateProfile: async (app, newProfile) => {
-    await updateProfile(app.auth.currentUser, newProfile);
+    await fbUpdateProfile(app.auth.currentUser, newProfile);
   }
 };
 
 export {
   firestore,
-  auth,
-  uid
-};
+  auth
+}; // uid is exported above


### PR DESCRIPTION
## Summary
- remove duplicate `uid` export and alias `updateProfile`
- drop unused Firebase imports from utils

## Testing
- `node --check public/js/utils.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad94621f00832e8f1e23644cd69bf2