### PR TITLE
Fix Firestore helpers and guard community page events

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -6,7 +6,8 @@ import {
   addDoc,
   updateDoc,
   deleteDoc,
-  query
+  query,
+  setDoc
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import {
   onAuthStateChanged,
@@ -49,6 +50,10 @@ const store = {
 export { store };
 export function uid(prefix='id'){ return prefix + '_' + Math.random().toString(36).slice(2,9); }
 export function formatDate(d){ try{ return new Date(d).toISOString().slice(0,10); }catch{ return d; } }
+
+// Streak helpers
+const streakStatus = ['Medalha de Bronze', 'Medalha de Prata', 'Medalha de Ouro', 'Imortal'];
+const statusMilestones = [7, 30, 90, 365];
 
 const firestore = {
   get: async (db, uid, collectionName) => {
@@ -93,6 +98,13 @@ const firestore = {
   }
 };
 
+// Backwards compatibility helpers
+firestore.getAll = firestore.get;
+firestore.set = async (db, uid, collectionName, id, data) => {
+  const docRef = doc(db, "users", uid, collectionName, id);
+  await setDoc(docRef, data);
+};
+
 const auth = {
   checkAuthState: (app, callback) => {
     onAuthStateChanged(app.auth, (user) => {
@@ -126,5 +138,7 @@ const auth = {
 
 export {
   firestore,
-  auth
+  auth,
+  streakStatus,
+  statusMilestones
 }; // uid is exported above

--- a/public/pages/comunidade.js
+++ b/public/pages/comunidade.js
@@ -1,4 +1,5 @@
 import { firestore, auth, uid } from '../js/utils.js';
+import { where, limit } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
 export function initPage(app){
   const btnSalvar = document.getElementById('btn-salvar-perfil');
@@ -8,7 +9,7 @@ export function initPage(app){
   const btnExcluirConta = document.getElementById('btn-excluir-conta');
 
   // Funcionalidade de Excluir Conta
-  btnExcluirConta.addEventListener('click', () => {
+  if (btnExcluirConta) btnExcluirConta.addEventListener('click', () => {
     app.openModal('Excluir Conta', `
       <div class="field">
         <label class="label">Confirme sua senha para continuar</label>
@@ -39,7 +40,7 @@ export function initPage(app){
   });
 
   // Funcionalidade de Gerar Código de Acervo
-  btnGerarCodigo.addEventListener('click', async () => {
+  if (btnGerarCodigo) btnGerarCodigo.addEventListener('click', async () => {
     const myLibrary = await firestore.get(app.db, app.uid, 'library');
     if(myLibrary.length === 0){
         app.toast('Seu acervo está vazio!');
@@ -67,7 +68,7 @@ export function initPage(app){
   });
 
   // Funcionalidade de Vincular Código
-  btnVincularCodigo.addEventListener('click', () => {
+  if (btnVincularCodigo) btnVincularCodigo.addEventListener('click', () => {
     app.openModal('Vincular Acervo', `
       <form id="frm-vincular-codigo">
         <div class="field">
@@ -100,7 +101,7 @@ export function initPage(app){
   });
 
   // Funcionalidade de Importar
-  btnImportar.addEventListener('click', () => {
+  if (btnImportar) btnImportar.addEventListener('click', () => {
     app.openModal('Importar Dados', `
       <form id="frm-importar">
         <div class="field">


### PR DESCRIPTION
## Summary
- export streak milestone constants and provide `getAll`/`set` helpers for Firestore
- import Firestore query helpers and skip event bindings when community page buttons are absent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad97373254832eaddeab0cb4a6713f